### PR TITLE
Added more defensive programming to handle non-semver values

### DIFF
--- a/auto_semver/git.py
+++ b/auto_semver/git.py
@@ -12,7 +12,7 @@ class GitTagSource(object):
     def _get_remote_tags(self):
         # Git command to list remote tags, only grabbing tags and not the
         # commit hashes.
-        tag_command = "git ls-remote --tags -q {} | awk '{{print $2}}'".format(
+        tag_command = "git ls-remote --tags --refs -q {} | awk '{{print $2}}'".format(
             self.custom_remote
         )
 
@@ -41,7 +41,12 @@ class GitTagSource(object):
         for line in raw_semver_text.splitlines():
             # Removing the fixed part of the git tag output we won't need.
             line_cleaned = line.replace("refs/tags/", "")
-            semver = Semver(line_cleaned)
+            try:
+                semver = Semver(line_cleaned)
+            except ValueError:
+                # It is just an invalid semver, and we will continue
+                # along without using it.
+                continue
 
             if semver is not None:
                 semver_result_output.append(semver)

--- a/auto_semver/semver.py
+++ b/auto_semver/semver.py
@@ -4,11 +4,16 @@ import re
 
 class Semver(object):
     def __init__(self, semver_string):
-        semver_dict = self.parse_semver_string(semver_string)
+        self.original_semver_string = semver_string
+        semver_dict = self._parse_semver_string(semver_string)
 
         if semver_dict is None:
             # We were not able to parse the semver string, return an error
-            return None
+            raise ValueError(
+                "Invalid semver string, {}, being parsed.".format(
+                    self.original_semver_string
+                )
+            )
 
         self.semver = semver_dict["semver"]
         self.major = semver_dict["major"]
@@ -18,7 +23,7 @@ class Semver(object):
         self.version_prefix = semver_dict["version_prefix"]
         self.buildmetadata = semver_dict["buildmetadata"]
 
-    def parse_semver_string(self, semver_string):
+    def _parse_semver_string(self, semver_string):
         semver_dict = {"version_prefix": False}
 
         # This is a wild regex, but it comes directly from the semver docs.


### PR DESCRIPTION
We are also using a slightly different git ls-remote command to only retrieve one type of git tag from the remote (before we were running into a situation where two different types of git tags were returned). 