### PR TITLE
Git tagger functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ Auto-incrementing a minor version.
 Just print out the current highest git semver tag.
 
 `auto-semver --print-highest`
+
+You can also have auto-semver create a git tag for you locally by running a `git tag` command.
+
+`auto-semver -t`

--- a/auto_semver/__main__.py
+++ b/auto_semver/__main__.py
@@ -1,7 +1,7 @@
 import sys
 
 from auto_semver.cli import parse_cli_arguments
-from auto_semver.git import GitTagSource
+from auto_semver.git import GitTagSource, GitTagger
 from auto_semver.auto_semver import AutoSemver
 
 
@@ -12,7 +12,13 @@ def main():
     # For now, the only one we support is the GitTagSource
     git_semver_list = GitTagSource(args.use_local).get_semver_list()
     a = AutoSemver(git_semver_list, args.value, args.print_highest)
-    a.auto_increment_semver()
+    next_tag = a.auto_increment_semver()
+
+    if args.should_tag:
+        git_tagger = GitTagger(next_tag)
+        git_tagger.tag_local()
+    else:
+        print(next_tag)
 
 
 if __name__ == "__main__":

--- a/auto_semver/auto_semver.py
+++ b/auto_semver/auto_semver.py
@@ -49,7 +49,7 @@ class AutoSemver(object):
         if self.next_semver.version_prefix == True:
             semver_string = "v{}".format(self.next_semver.semver)
 
-        print(semver_string)
+        return semver_string
 
     def get_highest_semver_from_list(self):
         # We will start our comparisons with the first tag in the list.

--- a/auto_semver/cli.py
+++ b/auto_semver/cli.py
@@ -40,4 +40,14 @@ def parse_cli_arguments():
         help="Should the script reference local git tags instead of remote?",
     )
 
+    parser.add_argument(
+        "-t",
+        "--tag",
+        dest="should_tag",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Do you want auto-semver to automatically create a new git tag for you locally?",
+    )
+
     return parser.parse_args()

--- a/auto_semver/git.py
+++ b/auto_semver/git.py
@@ -4,6 +4,36 @@ import sys
 from auto_semver.semver import Semver
 
 
+class GitTagger(object):
+    def __init__(self, semver_tag):
+        self.semver_tag = semver_tag
+
+    def tag_local(self):
+        tag_command = "git tag {}".format(self.semver_tag)
+
+        command_output = subprocess.run(
+            tag_command,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+
+        # Checking to make sure our command succeeded. The stdout() function
+        # returns None if the command fails and there is no output.
+        if "already exists" in command_output.stderr:
+            sys.exit(
+                "Git tag: {} already exists locally. Doing nothing...".format(
+                    self.semver_tag
+                )
+            )
+
+        elif command_output.stderr != "":
+            sys.exit("Error creating git tags locally...")
+
+        print("Created {} git tag locally".format(self.semver_tag))
+
+
 class GitTagSource(object):
     # Class that grabs tags from a git remote
     def __init__(self, use_local, custom_remote=""):


### PR DESCRIPTION
Allows the script to run a `git tag` command for you with the next semver tag as calculated by the script's usual rules.